### PR TITLE
Library Update to Support APRS Messages without correct time

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ZeroAPRS",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "ZoroAPRS is a simple APRS library with DAC for samd21 based arduino boards.",
   "repository": {
     "type": "git",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ZeroAPRS
-version=1.0
+version=1.0.2
 author=Hakkı CAN <hkkcan@gmail.com>
 maintainer=Hakkı CAN
 sentence=ZoroAPRS is a simple APRS library with DAC for samd21 based arduino boards.

--- a/src/ZeroAPRS.cpp
+++ b/src/ZeroAPRS.cpp
@@ -2,7 +2,7 @@
  * ZoroAPRS is a simple aprs library with DAC for samd21 based arduino boards.
  * The ZoroAPRS library was developed only for LightAPRS hardware.
  * 
- * Copyright (C) 2019 HAKKI CAN (TA2NHP) <hkkcan@gmail.com> www.hakkican.com
+ * Copyright (C) 2024 HAKKI CAN (TA2NHP) <hkkcan@gmail.com> www.hakkican.com
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -137,8 +137,13 @@ void APRS_setPathSize(uint8_t pathSize) {
 
 void APRS_setTimeStamp(uint8_t hh, uint8_t mm, uint8_t ss) {
   memset(APRS.TIMESTAMP, 0, 7);
-  sprintf(APRS.TIMESTAMP, "%02d%02d%02d", hh, mm, ss);
-  APRS.TIMESTAMP[6] = 'h';
+  if(hh == 99 && mm == 99 && ss == 99) {
+	  APRS.TIMESTAMP[0] = '\0';
+  }
+  else {
+	  sprintf(APRS.TIMESTAMP, "%02d%02d%02d", hh, mm, ss);
+  	  APRS.TIMESTAMP[6] = 'h';
+  }
 }
 
 void APRS_setLat(char *lat) {
@@ -413,4 +418,9 @@ void APRS_tcDisable()
 {
   TC5->COUNT16.CTRLA.reg &= ~TC_CTRLA_ENABLE;
   while (APRS_tcIsSyncing());
+}
+
+char* APRS_getTrack()
+{
+	return APRS.TRACK;
 }

--- a/src/ZeroAPRS.h
+++ b/src/ZeroAPRS.h
@@ -58,3 +58,4 @@ void APRS_tcStartCounter(void);
 void APRS_tcReset(void);
 void APRS_tcDisable(void);
 void TC5_Handler (void);
+char* APRS_getTrack();


### PR DESCRIPTION
The current library assumes that the code sending the APRS message has the correct time, either from a GPS fix or internal clock.  The APRS standard allows for messages to be sent without a timestamp.  In order to do this according to the spec, the setTimestamp function has been modified to accept an invalid time of 99:99:99, which will then omit the timestamp from the APRS message.  It is up to the calling function to set the SYMBOL and SYMBOLTABLE correctly to meet the APRS spec for a message without correct time.

In addition, a missing getter function for the APRS.TRACK variable was added to aid in debugging.  This Getter function will return the track value, which can then be placed into a log or output to console. 

The library has been versioned to 1.0.2 in order to avoid conflicts with the 1.0.1 label I used internally.